### PR TITLE
 step-by-step instructions to set up Oracle Observability exporter and Grafana

### DIFF
--- a/oracle-metrics/oracle-observability-exporter-deployment.yaml
+++ b/oracle-metrics/oracle-observability-exporter-deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oracle-observability-exporter
+  labels:
+    app: oracle-observability-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: oracle-observability-exporter
+  template:
+    metadata:
+      labels:
+        app: oracle-observability-exporter
+    spec:
+      volumes:
+        - name: log-volume
+          emptyDir: {}  # This will create an empty directory for logs. You can change this to a PersistentVolume if needed.
+      containers:
+        - name: exporter
+          image: container-registry.oracle.com/database/observability-exporter:1.5.5
+          ports:
+            - containerPort: 9161
+          volumeMounts:
+            - name: log-volume
+              mountPath: /log
+          envFrom:
+            - secretRef:
+                name: oracle-observability-secrets
+          env:
+            - name: ORACLE_EXPORTER_LOG_PATH
+              value: "/log/alert.log"  # Point to the correct log path
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: oracle-observability-exporter
+spec:
+  selector:
+    app: oracle-observability-exporter
+  ports:
+    - protocol: TCP
+      port: 9161
+      targetPort: 9161

--- a/oracle-metrics/oracle-servicemonitor.yaml
+++ b/oracle-metrics/oracle-servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: oracle-exporter-monitor
+  namespace: oracle-monitoring
+  labels:
+    release: prometheus  # IMPORTANT: Prometheus uses this label to pick it up
+spec:
+  selector:
+    matchLabels:
+      app: oracle-observability-exporter
+  namespaceSelector:
+    matchNames:
+      - oracle-monitoring
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s

--- a/oracle-metrics/readme.md
+++ b/oracle-metrics/readme.md
@@ -1,0 +1,23 @@
+# Oracle Observability & Grafana Setup on OpenShift
+
+This guide provides step-by-step instructions to set up [Oracle Observability exporter](https://github.com/oracle/oracle-db-appdev-monitoring) and Grafana on an OpenShift cluster for monitoring Oracle database metrics.
+
+The Oracle Observability exporter collects metrics from an Oracle database and exposes them in a Prometheus-compatible format. Grafana, in turn, is used to visualize these metrics in a customizable dashboard.
+
+This setup is ideal for platform engineers, DBAs, and developers who want to integrate Oracle database monitoring into their Kubernetes-native observability stack using Prometheus and Grafana.
+
+## Prerequisites
+
+- Access to an OpenShift cluster with cluster-admin or sufficient permissions.
+- A running Oracle database (on-cluster or external).
+- OpenShift CLI (`oc`) installed and authenticated.
+
+
+## Setting up the Oracle Observability pod
+An [open-source exporter](https://github.com/oracle/oracle-db-appdev-monitoring) that extracts Oracle database metrics and exposes them via an HTTP endpoint for Prometheus scraping.
+
+Please find the instructions to set up the [Oracle Observability exporter](./setup-oracle-exporter.md).
+
+## Setting up the grafana dashboards
+
+Please find the instructions to set up the [Grafana instance and dashboards](./setup-grafana.md).

--- a/oracle-metrics/setup-grafana.md
+++ b/oracle-metrics/setup-grafana.md
@@ -1,0 +1,98 @@
+# 📊 Grafana Setup on OpenShift with Prometheus Datasource
+
+This guide covers:
+
+- Installing Grafana Operator on OpenShift
+- Deploying a Grafana instance
+- Retrieving Prometheus token and service URL
+- Accessing Grafana UI
+- Manually adding Prometheus datasource
+- Import the dashboards
+
+---
+
+## 🧱 Prerequisites
+
+- OpenShift CLI (`oc`) installed and configured
+- User with appropriate permissions
+- Prometheus deployed by OpenShift Monitoring (`openshift-monitoring` namespace)
+
+---
+
+## Step 1: Install Grafana Operator via OperatorHub
+
+Login to openshift console and install the grafana operator. Operators --> OperatorHub --> search for grafana --> Install the grafana operator.
+
+Once you install wait for some time to initialize the operator.
+
+## Step 2: Deploy a Grafana Instance
+Go to Operators --> installed operators --> Grafana Operator --> ALl instances --> "Create new" dropdown --> select grafana and fill the details you want to modify from default values.
+
+Wait for the grafana pod to be initialized. This may not create an openshift route for you. If not create a route so that you can access the grafana outside the cluster. 
+
+
+## Step 3: Get Prometheus Token
+
+We are planning to use the prometheus instance available with openshift cluster. To access the prometheus token outside the cluster we need to get the token. This step will generate the token which does not expire.
+
+Create a manual secret of type `kubernetes.io/service-account-token`:
+```shell
+oc create secret generic prometheus-k8s-token \
+  --type kubernetes.io/service-account-token \
+  --from-literal=extra=unused \
+  -n openshift-monitoring
+```
+Then link it to the `prometheus-k8s` ServiceAccount. This will trigger the token controller to populate the secret with a long-lived token.
+```shell
+oc patch secret prometheus-k8s-token \
+  -p '{"metadata":{"annotations":{"kubernetes.io/service-account.name":"prometheus-k8s"}}}' \
+  -n openshift-monitoring
+```
+Wait a few seconds, then verify if the token is updated/created. Capture this token and you need this in the next step.
+
+```shell
+oc get secret prometheus-k8s-token -n openshift-monitoring -o jsonpath='{.data.token}' | base64 -d
+```
+
+## Step 4: Log in to Grafana
+
+Once you find the grafana route to access the web application then you need login credentials.
+
+Grafana operator creates the secret to access the grafana console. usually it wil be `<grafan-instance-name>-admin-credentials`. This secret is going to have credentials to login into the grafana console.
+
+https://thanos-querier.openshift-monitoring.svc:9091
+
+
+## Step 5: Manually Add Prometheus Datasource
+
+After logging into Grafana:
+
+1. Navigate to **⚙️ Configuration** → **Data Sources**
+2. Click **"Add data source"**
+3. Select **Prometheus**
+4. In the settings form, enter the following details:
+
+   | Field     | Value                                                                 |
+      |-----------|-----------------------------------------------------------------------|
+   | **Name**  | `OpenShift Prometheus`                                               |
+   | **Prometheus server URL**      | `https://thanos-querier.openshift-monitoring.svc:9091`               |
+
+5. Scroll down to the **HTTP Headers** section:
+    - Add Header as `Authorization`
+    - Add the header value as `Bearer <REPLACE_PROMOTHEUS_TOKEN>` ## Paste the token retrieved in **Step 3: Get Prometheus Token**
+
+6. Under TLS Settings --> Enable "Skip TLS certificate validation"
+7. Click **Save & Test**
+
+You should see ✅ **"Data source is working"**
+
+## Step 6: Import the grafana dashboards.
+
+Import the required dashboards you want to monitor. Go to dashboards and import the below dashboards.
+
+* Import the oracledb monitoring performance and table space stats.
+  https://grafana.com/grafana/dashboards/13555-oracledb-monitoring-performance-and-table-space-stats/
+* Import the simple oracledb monitoring
+  https://grafana.com/grafana/dashboards/3333-oracledb/
+* Import the openshift virutalization dashboard from the URL
+  https://raw.githubusercontent.com/leoaaraujo/articles/master/openshift-virtualization-monitoring/files/ocp-v-dashboard.json

--- a/oracle-metrics/setup-oracle-exporter.md
+++ b/oracle-metrics/setup-oracle-exporter.md
@@ -1,0 +1,72 @@
+# 📊 Oracle Observability Exporter Setup on OpenShift
+
+This guide covers:
+
+- Create the oracle user with required permissions.
+- Deploy the oracle exporter pod.
+- Set up the prometheus `ServiceMonitor` to scrape the data.
+
+---
+## 🧱 Prerequisites
+
+- OpenShift CLI (`oc`) installed and configured
+- User with appropriate permissions
+- Create all necessary namespaces mentioned in the `deployment` yaml files.
+
+---
+### Step 1: Create the oracle user with the required permissions
+You can create the oracle user with the required permissions mentioned on the [oracle-db-appdev-monitoring project](https://github.com/oracle/oracle-db-appdev-monitoring?tab=readme-ov-file#database-permissions-required).
+
+Following are some sample queries and not recommend to use AS-IS:
+
+```shell
+CREATE USER metrics_user IDENTIFIED BY <SELECT_PASSWORD>;
+GRANT CONNECT TO metrics_user;
+GRANT SELECT ANY DICTIONARY TO metrics_user;
+GRANT SELECT ON V_$SESSION TO metrics_user;
+GRANT SELECT ON V_$SYSSTAT TO metrics_user;
+
+GRANT SELECT ON V_$SYSSTAT TO metrics_user;
+GRANT SELECT ON V_$SESSION TO metrics_user;
+GRANT SELECT ON V_$PROCESS TO metrics_user;
+GRANT SELECT ANY DICTIONARY TO metrics_user;
+
+# This will grant all the DBA permissions.
+GRANT DBA TO metrics_user;
+```
+### Step 2: Create the oracle credentials secret
+Create the Oracle Credentials secret so that oracle exporter can refer that.
+
+```shell
+oc create secret generic oracle-observability-secrets \
+--from-literal=DB_USERNAME="metrics_user" \
+--from-literal=DB_PASSWORD=<REPLACE_PASSWORD> \
+--from-literal=DB_CONNECT_STRING=<ORACLE_HOST>:1521/pdb1
+```
+
+### Step 3: Deploy the oracle observability pod.
+
+Deploy the oracle observability pod using below command:
+
+```shell
+oc apply -f oracle-observability-exporter-deployment.yaml
+```
+
+### Step 4: Check if the pod is up.
+After deployment, it will take some time to spin up the pod. Observe the pod logs/events for any errors.
+
+The route will not be added by default so add the route to the pod and see if the API `/metrics` is up.
+
+```
+http://<ROUTE_of_Pod>/metrics
+```
+Above API will return prometheus metrics exposed as part of the oracle observability pod.  
+
+### Step 5: set up the prometheus ServiceMonitor.
+Now oracle observability pod is up but openshift prometheus does not scrape the data automatically until you create a `ServiceMonitor`
+
+```shell
+oc apply -f oracle-servicemonitor.yaml
+```
+
+Once this is implemented you should be able to see the   data in openshift prometheus instance.


### PR DESCRIPTION
This guide provides step-by-step instructions to set up Oracle Observability exporter and Grafana on an OpenShift cluster for monitoring Oracle database.